### PR TITLE
update(workflows): use pull requests option for leaderboard workflow

### DIFF
--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}
@@ -21,5 +22,6 @@ jobs:
         uses: kristof-low/github-contributor-leaderboard@v1
         with:
           commit-message: "docs(readme): update contributor leaderboard"
+          use-pull-requests: "true"
 
 

--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -22,6 +22,6 @@ jobs:
         uses: kristof-low/github-contributor-leaderboard@beta
         with:
           commit-message: "docs(readme): update contributor leaderboard"
-          use-pull-requests: "true"
+          use-pull-request: "true"
 
 

--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Update Leaderboard
-        uses: kristof-low/github-contributor-leaderboard@v1
+        uses: kristof-low/github-contributor-leaderboard@beta
         with:
           commit-message: "docs(readme): update contributor leaderboard"
           use-pull-requests: "true"


### PR DESCRIPTION
  Since the main branch is protected from pushes,
  use the pull requests option (with the necessary
  permissions) for the update-contributor-leaderboard
  workflow.