### PR TITLE
fix(workflows): fix leaderboard workflow to respect branch rulesets

### DIFF
--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}
@@ -21,4 +22,5 @@ jobs:
         uses: kristof-low/github-contributor-leaderboard@v1
         with:
           commit-message: "docs(readme): update contributor leaderboard"
+          use-pull-request: "true"
 

--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,7 +12,6 @@ jobs:
 
     permissions:
       contents: write
-      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Due to the 'main' branch's branch protection rules,  the update-contributor-leaderboard workflow is currently  failing everytime since it tries to push to main which only accepts pull-requests.

This commit updates the workflow to specify that a pull-request must be created.