### PR TITLE
fix(workflows): update leaderboard workflow permissions

### DIFF
--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
 Added the `pull-requests: write` permission to the leaderboard workflow to enable the action used to create a pull-request with the updated `README.md`.